### PR TITLE
Add libunwind to dist

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,19 +2,6 @@ common --dynamic_mode=off
 # Upstream builds PIE, but it doesn't have much benefit when fully statically linked.
 #common --force_pic
 
-common --bes_results_url=https://app.buildbuddy.io/invocation/
-common --bes_backend=grpcs://remote.buildbuddy.io
-common --remote_cache=grpcs://remote.buildbuddy.io
-common --remote_download_toplevel
-common --nobuild_runfile_links
-common --remote_timeout=3600
-common --remote_executor=grpcs://remote.buildbuddy.io
-common --noexperimental_throttle_remote_action_building
-common --jobs=800
-
-common --extra_execution_platforms=//rbe_platform
-common --host_platform=//rbe_platform
-
 common --platforms @zig_sdk//libc_aware/platform:linux_amd64_musl
 common --experimental_platform_in_output_dir
 

--- a/BUILD
+++ b/BUILD
@@ -95,6 +95,7 @@ pkg_files(
             ":bins" + suffix,
             "//:builtin_headers_pkg_files",
             "@llvm-raw//:libcxx_include",
+            "@llvm-project//libunwind:unwind",
         ] + select({
             "@bazel_tools//src/conditions:darwin": [":libclang_rt.profile_osx"],
             "@bazel_tools//src/conditions:linux_aarch64": [":libclang_rt.profile_aarch64"],


### PR DESCRIPTION
This adds libunwind to the dist archive. This should allow us to build on Mac.